### PR TITLE
feat(Community): link to CONTRIBUTING.md

### DIFF
--- a/layouts/partials/community_links.html
+++ b/layouts/partials/community_links.html
@@ -14,7 +14,7 @@
 {{ with index $links "developer"}}
 {{ template "community-links-list"  . }}
 {{ end }}
-<p>You can find out how to contribute to these docs in our <a href="/docs/contribution-guidelines/">Contribution Guidelines</a>.
+<p>You can find out how to contribute to these docs in our <a href="{{ .Param "github_project_repo" }}/blob/master/CONTRIBUTING.md">Contributing Guidelines</a>.
 </div>
 </section>
 


### PR DESCRIPTION
The CONTRIBUTING.md should be in the source repo, and contributing guidelines are not a part of the documentation, so instead of keeping two copies or linking from one to the other, we can directly link to CONTRIBUTING.md.